### PR TITLE
Fix unable to repair wooden hoe

### DIFF
--- a/Whetstone/Whetstone.cs
+++ b/Whetstone/Whetstone.cs
@@ -82,7 +82,7 @@ namespace Whetstone
 
         private static bool NeedRepair(DurabilityItem item)
         {
-            return item.DurabilityRate <= 1.0f;
+            return item.GetDurability() < DurabilityItem.DurabilityMax;
         }
     }
 


### PR DESCRIPTION
Verify if the current item has a durability below it's max durability.

To fix #8 